### PR TITLE
Fix args

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,8 +33,6 @@ type Ping struct {
 	Rssult string
 }
 
-type User e.User
-
 // func 関数名 (引数 型, 引数 型)
 // JSON 形式で結果を返却
 // data interface{} とすると、どのような変数の型でも引数として受け取ることができる
@@ -88,7 +86,7 @@ func signup(w http.ResponseWriter, r *http.Request) {
 	//p, err := s.CreateUser(&user)
 	var s s.Service
 	spew.Dump(&user)
-	p, err := s.CreateUser(user.Email, user.Password)
+	p, err := s.CreateUser(&user)
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		//Dumpを吐く

--- a/service/user_service.go
+++ b/service/user_service.go
@@ -8,14 +8,11 @@ import (
 // Service procides user's behavior
 type Service struct{}
 
-// User is alias of entity.User struct
-type User entity.User
-
 // GetAll is get all User
-func (s Service) GetAll() ([]User, error) {
+func (s Service) GetAll() ([]entity.User, error) {
 	// DB connect
 	db := db.GetDB()
-	var u []User
+	var u []entity.User
 
 	if err := db.Find(&u).Error; err != nil {
 		return nil, err
@@ -24,17 +21,14 @@ func (s Service) GetAll() ([]User, error) {
 	return u, nil
 }
 
-func (s Service) MyFunc(user *User) (User, error) {
+func (s Service) MyFunc(user *entity.User) (*entity.User, error) {
 	db := db.GetDB()
-	var u User
-	u.Email = user.Email
-	u.Password = user.Password
 
-	if err := db.Create(&u).Error; err != nil {
-		return u, err
+	if err := db.Create(&user).Error; err != nil {
+		return nil, err
 	}
 
-	return u, nil
+	return user, nil
 }
 
 // CreateModel is create User model
@@ -54,56 +48,51 @@ func (s Service) MyFunc(user *User) (User, error) {
 // }
 
 // CreateUser is create User
-func (s Service) CreateUser(email string, password string) (User, error) {
+func (s Service) CreateUser(user *entity.User) (*entity.User, error) {
 	// func (s Service) CreateUser(u *User) (User, error) {
 	db := db.GetDB()
-	// var user User
-	var user User
-
-	user.Email = email
-	user.Password = password
 	//user.Description = "It`s Twitter username"
 	//db.Save(&user)
 	if err := db.Create(&user).Error; err != nil {
-		return user, err
+		return nil, err
 	}
 	return user, nil
 }
 
 // GetByID is get a User
-func (s Service) GetByID(id string) (User, error) {
+func (s Service) GetByID(id string) (*entity.User, error) {
 	db := db.GetDB()
-	var u User
+	var u entity.User
 
 	if err := db.Where("id = ?", id).First(&u).Error; err != nil {
-		return u, err
+		return nil, err
 	}
 
-	return u, nil
+	return &u, nil
 }
 
 // GetByEmail&Password
-func (s Service) GetByEmailAndPassword(email string, password string) (User, error) {
+func (s Service) GetByEmailAndPassword(email string, password string) (*entity.User, error) {
 	db := db.GetDB()
-	var u User
+	var u entity.User
 
 	if err := db.Where(" email = ? AND password = ?", email, password).First(&u).Error; err != nil {
-		return u, err
+		return nil, err
 	}
 
-	return u, nil
+	return &u, nil
 }
 
 // GetByPassword
-func (s Service) GetByPassword(email string) (User, error) {
+func (s Service) GetByPassword(email string) (*entity.User, error) {
 	db := db.GetDB()
-	var u User
+	var u entity.User
 
 	if err := db.Where(" email = ?", email).First(&u).Error; err != nil {
-		return u, err
+		return nil, err
 	}
 
-	return u, nil
+	return &u, nil
 }
 
 // UpdateByID is update a User
@@ -127,7 +116,7 @@ func (s Service) GetByPassword(email string) (User, error) {
 // DeleteByID is delete a User
 func (s Service) DeleteByID(id string) error {
 	db := db.GetDB()
-	var u User
+	var u entity.User
 
 	if err := db.Where("id = ?", id).Delete(&u).Error; err != nil {
 		return err


### PR DESCRIPTION
https://github.com/dsaa151562000/golang_jwt/issues/1#issuecomment-573379607

これについての回答になります。
原因としては main, user package でそれぞれ

```go
type User entity.User
```

を定義していたからになります。
package が変わると同じ名前の `type` で同じ `entity.User` を使っていたとしても違う型になります。

なので今回は type による別名を使用せずに `entity.User` をそのまま使うように変更いたしました。
今回の用途であれば `type` で型を使わずとも `entity.User` をそのまま使用する、で良いと思います。